### PR TITLE
Update README: project-level install guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ the [Agent Skills spec](https://agentskills.io).
 
 ## Install
 
+> **Project-level only** — do not install globally.
+> The skill instructions reference `.claude/skills/` paths relative to the
+> project root, so a global install (`~/.claude/skills/`) will break script
+> execution. Install once per project that needs it.
+
 ```bash
-npx skills add <your-github-id>/frontend-visual-tdd
+npx skills add ludacirs/frontend-visual-tdd-skill
 ```
 
 Then run setup once to install Playwright and Chromium:


### PR DESCRIPTION
## Summary
- README에 프로젝트 레벨 전용 설치 안내 추가 (글로벌 설치 시 경로 문제 명시)
- 설치 명령어를 실제 레포명(`ludacirs/frontend-visual-tdd-skill`)으로 수정

## Test plan
- [ ] `npx skills add ludacirs/frontend-visual-tdd-skill`로 프로젝트 레벨 설치 확인
- [ ] 설치 후 `npm run setup` 정상 동작 확인