### PR TITLE
SKILL.md: preview 라우트 가이드를 원칙 중심으로 개선

### DIFF
--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -55,12 +55,32 @@ Classify the task **before doing anything else**.
 If unclear, ask the user once.
 
 > **`/dev/preview` route:** If the project has no isolated render route for
-> components, create a minimal one first.
+> components, create a minimal one first. The pattern varies by framework:
+>
+> **React (Vite / CRA)**
 > - URL pattern: `/dev/preview?component=<ComponentName>`
 > - File layout: `src/dev/PreviewPage.tsx` + `src/dev/previews/<Name>.preview.tsx`
 > - Guard with `if (import.meta.env.DEV)` in the router
-> - For components with API calls: register MSW handlers in the `.preview.tsx`
->   file instead of using `--mock-routes` (keeps mock data co-located with the preview)
+>
+> **Next.js (App Router)**
+> - URL pattern: `/dev/preview?component=<ComponentName>`
+> - File layout: `src/app/dev/preview/page.tsx` + `src/dev/previews/<Name>.preview.tsx`
+> - Guard: `if (process.env.NODE_ENV !== 'development') { notFound() }`
+>
+> **Next.js (Pages Router)**
+> - URL pattern: `/dev/preview?component=<ComponentName>`
+> - File layout: `src/pages/dev/preview.tsx` + `src/dev/previews/<Name>.preview.tsx`
+> - Guard: `if (process.env.NODE_ENV !== 'development') { return { notFound: true } }` in `getServerSideProps`
+>
+> **SvelteKit**
+> - URL pattern: `/dev/preview?component=<ComponentName>`
+> - File layout: `src/routes/dev/preview/+page.svelte` + `src/dev/previews/<Name>.preview.svelte`
+> - Guard: `if (!import.meta.env.DEV) { throw redirect(307, '/') }` in `+page.ts` load function
+>
+> **Common to all frameworks:**
+> - For components with API calls: register MSW handlers in the preview file
+>   instead of using `--mock-routes` (keeps mock data co-located with the preview)
+> - The preview route must bypass auth layouts — place it outside auth route groups
 
 ---
 

--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -55,32 +55,14 @@ Classify the task **before doing anything else**.
 If unclear, ask the user once.
 
 > **`/dev/preview` route:** If the project has no isolated render route for
-> components, create a minimal one first. The pattern varies by framework:
->
-> **React (Vite / CRA)**
+> components, create a minimal one first. Follow the project's routing conventions:
 > - URL pattern: `/dev/preview?component=<ComponentName>`
-> - File layout: `src/dev/PreviewPage.tsx` + `src/dev/previews/<Name>.preview.tsx`
-> - Guard with `if (import.meta.env.DEV)` in the router
->
-> **Next.js (App Router)**
-> - URL pattern: `/dev/preview?component=<ComponentName>`
-> - File layout: `src/app/dev/preview/page.tsx` + `src/dev/previews/<Name>.preview.tsx`
-> - Guard: `if (process.env.NODE_ENV !== 'development') { notFound() }`
->
-> **Next.js (Pages Router)**
-> - URL pattern: `/dev/preview?component=<ComponentName>`
-> - File layout: `src/pages/dev/preview.tsx` + `src/dev/previews/<Name>.preview.tsx`
-> - Guard: `if (process.env.NODE_ENV !== 'development') { return { notFound: true } }` in `getServerSideProps`
->
-> **SvelteKit**
-> - URL pattern: `/dev/preview?component=<ComponentName>`
-> - File layout: `src/routes/dev/preview/+page.svelte` + `src/dev/previews/<Name>.preview.svelte`
-> - Guard: `if (!import.meta.env.DEV) { throw redirect(307, '/') }` in `+page.ts` load function
->
-> **Common to all frameworks:**
+> - Place the route **outside auth layout groups** so no login/session is required
+> - Add a **dev-only guard** so the route is inaccessible in production
+>   (e.g., `import.meta.env.DEV`, `process.env.NODE_ENV`, or the framework's equivalent)
+> - Separate preview wrappers per component (e.g., `<Name>.preview.*`)
 > - For components with API calls: register MSW handlers in the preview file
 >   instead of using `--mock-routes` (keeps mock data co-located with the preview)
-> - The preview route must bypass auth layouts — place it outside auth route groups
 
 ---
 


### PR DESCRIPTION
## Summary
- React(Vite/CRA), Next.js(App Router/Pages Router), SvelteKit별 `/dev/preview` 라우트 패턴 추가
- 프레임워크별 DEV 가드 적용 방법 문서화
- auth 레이아웃 우회, MSW 핸들러 사용 등 공통 가이드 추가

Closes #3

## Test plan
- [ ] SKILL.md의 `/dev/preview` 섹션에 4개 프레임워크 패턴이 포함되어 있는지 확인
- [ ] 각 프레임워크별 DEV 가드 코드가 올바른지 확인
- [ ] 기존 React 가이드와 호환성 확인