### PR TITLE
Figma 이미지 자동 다운로드 스크립트(figma-export.ts) 추가

### DIFF
--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -79,10 +79,9 @@ What kind of task is this?
   │     └── Figma MCP connected?
   │           ├── Yes → find frame/component nodeId
   │           │         → run figma-export.ts to download expected image:
-  │           │           npx tsx .claude/skills/frontend-visual-tdd/scripts/figma-export.ts \
+  │           │           FIGMA_TOKEN=<TOKEN> npx tsx .claude/skills/frontend-visual-tdd/scripts/figma-export.ts \
   │           │             --file-key <FILE_KEY> --node-ids <NODE_ID> \
-  │           │             --token <FIGMA_TOKEN> --out visual-qa/expected \
-  │           │             --scale 1
+  │           │             --out visual-qa/expected --scale 1
   │           │         → note Figma frame width × height for viewport match
   │           └── No  → manual: export PNG from Figma UI → save to visual-qa/expected/
   │                     or assertion fallback (write selector/text list; skip diff)

--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -78,10 +78,14 @@ What kind of task is this?
   ├── New implementation / visual bug fix / redesign
   │     └── Figma MCP connected?
   │           ├── Yes → find frame/component nodeId
-  │           │         → mcp__figma__get_images
-  │           │         → save to visual-qa/expected/<task>.png
+  │           │         → run figma-export.ts to download expected image:
+  │           │           npx tsx .claude/skills/frontend-visual-tdd/scripts/figma-export.ts \
+  │           │             --file-key <FILE_KEY> --node-ids <NODE_ID> \
+  │           │             --token <FIGMA_TOKEN> --out visual-qa/expected \
+  │           │             --scale 1
   │           │         → note Figma frame width × height for viewport match
-  │           └── No  → assertion fallback (write selector/text list; skip diff)
+  │           └── No  → manual: export PNG from Figma UI → save to visual-qa/expected/
+  │                     or assertion fallback (write selector/text list; skip diff)
   │
   └── Refactor / internal change (no intentional visual change)
         → capture current rendering as expected BEFORE any code change:

--- a/skills/frontend-visual-tdd/scripts/figma-export.ts
+++ b/skills/frontend-visual-tdd/scripts/figma-export.ts
@@ -6,12 +6,12 @@
  * This script calls the Figma REST API directly to save images as files.
  *
  * Usage:
- *   npx tsx figma-export.ts --file-key <key> --node-ids <id,...> --token <token> --out <dir> [options]
+ *   FIGMA_TOKEN=<token> npx tsx figma-export.ts --file-key <key> --node-ids <id,...> --out <dir> [options]
  *
  * Options:
  *   --file-key   Figma file key (required)
  *   --node-ids   Comma-separated node IDs, e.g. "123:456,789:012" (required)
- *   --token      Figma Personal Access Token (required)
+ *   --token      Figma Personal Access Token (fallback; prefer FIGMA_TOKEN env var)
  *   --out        Output directory, e.g. visual-qa/expected (required)
  *   --scale      Image scale factor (default: 1)
  *   --format     png | jpg | svg | pdf (default: png)
@@ -41,24 +41,38 @@ const { values } = parseArgs({
 
 const args = values as Record<string, string | undefined>;
 
-if (!args['file-key'] || !args['node-ids'] || !args.token || !args.out) {
-  console.error('Usage: npx tsx figma-export.ts --file-key <key> --node-ids <id,...> --token <token> --out <dir>');
+if (!args['file-key'] || !args['node-ids'] || !args.out) {
+  console.error('Usage: FIGMA_TOKEN=<token> npx tsx figma-export.ts --file-key <key> --node-ids <id,...> --out <dir>');
   process.exit(1);
 }
 
 const fileKey = args['file-key'];
 const nodeIds = args['node-ids'].split(',').map((id) => id.trim());
-const token   = args.token.trim();
+const token   = (args.token ?? process.env.FIGMA_TOKEN ?? '').trim();
 const outDir  = args.out;
 const scale   = args.scale ?? '1';
 const format  = args.format ?? 'png';
+
+const VALID_FORMATS = ['png', 'jpg', 'svg', 'pdf'];
+if (!VALID_FORMATS.includes(format)) {
+  console.error(`[ERROR] Invalid format "${format}". Must be one of: ${VALID_FORMATS.join(', ')}`);
+  process.exit(1);
+}
+
+if (!token) {
+  console.error('Error: Figma token required. Set FIGMA_TOKEN env var or pass --token <token>');
+  process.exit(1);
+}
 
 if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
 
 // --- Figma API ---
 
-const idsParam = nodeIds.join(',');
-const apiUrl = `https://api.figma.com/v1/images/${fileKey}?ids=${idsParam}&format=${format}&scale=${scale}`;
+const apiUrlObj = new URL(`https://api.figma.com/v1/images/${encodeURIComponent(fileKey)}`);
+apiUrlObj.searchParams.set('ids', nodeIds.join(','));
+apiUrlObj.searchParams.set('format', format);
+apiUrlObj.searchParams.set('scale', scale);
+const apiUrl = apiUrlObj.toString();
 
 console.log(`[figma] Requesting images for ${nodeIds.length} node(s)...`);
 

--- a/skills/frontend-visual-tdd/scripts/figma-export.ts
+++ b/skills/frontend-visual-tdd/scripts/figma-export.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env tsx
+/**
+ * figma-export.ts — Download Figma frame images via REST API
+ *
+ * LLMs cannot access raw binary data from Figma MCP inline images.
+ * This script calls the Figma REST API directly to save images as files.
+ *
+ * Usage:
+ *   npx tsx figma-export.ts --file-key <key> --node-ids <id,...> --token <token> --out <dir> [options]
+ *
+ * Options:
+ *   --file-key   Figma file key (required)
+ *   --node-ids   Comma-separated node IDs, e.g. "123:456,789:012" (required)
+ *   --token      Figma Personal Access Token (required)
+ *   --out        Output directory, e.g. visual-qa/expected (required)
+ *   --scale      Image scale factor (default: 1)
+ *   --format     png | jpg | svg | pdf (default: png)
+ *
+ * Exit codes:
+ *   0 = success
+ *   1 = error (invalid args, API failure, download failure)
+ */
+
+import { mkdirSync, existsSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { parseArgs } from 'util';
+
+// --- Args ---
+
+const { values } = parseArgs({
+  options: {
+    'file-key': { type: 'string' },
+    'node-ids': { type: 'string' },
+    token:      { type: 'string' },
+    out:        { type: 'string' },
+    scale:      { type: 'string', default: '1' },
+    format:     { type: 'string', default: 'png' },
+  },
+  strict: false,
+});
+
+const args = values as Record<string, string | undefined>;
+
+if (!args['file-key'] || !args['node-ids'] || !args.token || !args.out) {
+  console.error('Usage: npx tsx figma-export.ts --file-key <key> --node-ids <id,...> --token <token> --out <dir>');
+  process.exit(1);
+}
+
+const fileKey = args['file-key'];
+const nodeIds = args['node-ids'].split(',').map((id) => id.trim());
+const token   = args.token.trim();
+const outDir  = args.out;
+const scale   = args.scale ?? '1';
+const format  = args.format ?? 'png';
+
+if (!existsSync(outDir)) mkdirSync(outDir, { recursive: true });
+
+// --- Figma API ---
+
+const idsParam = nodeIds.join(',');
+const apiUrl = `https://api.figma.com/v1/images/${fileKey}?ids=${idsParam}&format=${format}&scale=${scale}`;
+
+console.log(`[figma] Requesting images for ${nodeIds.length} node(s)...`);
+
+const res = await fetch(apiUrl, {
+  headers: { 'X-FIGMA-TOKEN': token },
+});
+
+if (!res.ok) {
+  const body = await res.text();
+  console.error(`[ERROR] Figma API returned ${res.status}: ${body}`);
+  if (res.status === 403) {
+    console.error('→ Check that your token is valid. Regenerate at https://www.figma.com/developers/api#access-tokens');
+  }
+  process.exit(1);
+}
+
+const data = (await res.json()) as { images: Record<string, string | null>; err: string | null };
+
+if (data.err) {
+  console.error(`[ERROR] Figma API error: ${data.err}`);
+  process.exit(1);
+}
+
+// --- Download images ---
+
+let downloaded = 0;
+
+for (const nodeId of nodeIds) {
+  const imageUrl = data.images[nodeId];
+
+  if (!imageUrl) {
+    console.error(`[WARN] No image URL for node ${nodeId} — skipping`);
+    continue;
+  }
+
+  const safeName = nodeId.replace(/:/g, '-');
+  const outPath  = join(outDir, `${safeName}.${format}`);
+
+  const imgRes = await fetch(imageUrl);
+  if (!imgRes.ok) {
+    console.error(`[ERROR] Failed to download image for node ${nodeId}: ${imgRes.status}`);
+    continue;
+  }
+
+  const buffer = Buffer.from(await imgRes.arrayBuffer());
+  writeFileSync(outPath, buffer);
+  console.log(`[figma] ${nodeId} → ${outPath}`);
+  downloaded++;
+}
+
+console.log(`\n[figma] Done: ${downloaded}/${nodeIds.length} image(s) saved to ${outDir}`);
+
+if (downloaded === 0) {
+  console.error('[ERROR] No images were downloaded.');
+  process.exit(1);
+}

--- a/skills/frontend-visual-tdd/scripts/package.json
+++ b/skills/frontend-visual-tdd/scripts/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "setup": "npm install && npx playwright install chromium --with-deps",
     "capture": "tsx capture.ts",
-    "diff": "tsx diff.ts"
+    "diff": "tsx diff.ts",
+    "figma-export": "tsx figma-export.ts"
   },
   "dependencies": {
     "pixelmatch": "^6.0.0",


### PR DESCRIPTION
## Summary
- `scripts/figma-export.ts` 신규 생성 — Figma REST API로 노드 이미지 직접 다운로드
- SKILL.md PHASE 0에서 figma-export.ts 사용을 기본 권장으로 변경, 토큰 없을 경우 수동 Export 가이드 추가
- package.json에 `figma-export` 스크립트 등록

Closes #4

## Test plan
- [ ] `npx tsx figma-export.ts --help` 동작 확인 (usage 출력)
- [ ] 유효한 토큰/fileKey/nodeId로 이미지 다운로드 확인
- [ ] 잘못된 토큰으로 403 에러 메시지 확인
- [ ] SKILL.md PHASE 0 플로우에 figma-export.ts 커맨드가 포함되어 있는지 확인