### PR TITLE
SKILL.md: MSW 환경에서 --mock-routes 미동작 문서화

### DIFF
--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -108,16 +108,23 @@ npx wait-on http://localhost:<PORT>
 **Step 2. Handle API calls (if any):**
 ```
 Does the target make API calls?
-  ├── component type → use MSW handlers in .preview.tsx (preferred)
-  │                    no --mock-routes needed
   │
-  ├── page / flow type → create a mock routes file and pass it to capture:
-  │     --mock-routes visual-qa/mocks/<task>.json
-  │     See references/mock-routes-example.json for format.
-  │     Mock every API call the page makes — unmocked calls cause
-  │     networkidle to hang or render incomplete state.
+  ├── no API calls → proceed without mocking
   │
-  └── no API calls → proceed without --mock-routes
+  └── yes → Does the project use MSW?
+        │
+        ├── MSW active → use worker.use() in preview file to override handlers.
+        │   ⚠ --mock-routes does NOT work when MSW is active.
+        │     (MSW intercepts at Service Worker level, before Playwright's
+        │      network-level route() can see the request.)
+        │   This applies to ALL task types (component, page, flow).
+        │
+        └── no MSW → use --mock-routes for page/flow types:
+              --mock-routes visual-qa/mocks/<task>.json
+              See references/mock-routes-example.json for format.
+              Mock every API call the page makes — unmocked calls cause
+              networkidle to hang or render incomplete state.
+              For component type, register mocks in .preview file.
 ```
 
 > **localStorage-based stores:** Stores that read `localStorage` at module load

--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -112,12 +112,16 @@ Does the target make API calls?
   ├── no API calls → proceed without mocking
   │
   └── yes → Does the project use MSW?
+        │   (Check: `msw` in package.json or `mockServiceWorker.js` in public/)
         │
-        ├── MSW active → use worker.use() in preview file to override handlers.
+        ├── MSW active
         │   ⚠ --mock-routes does NOT work when MSW is active.
         │     (MSW intercepts at Service Worker level, before Playwright's
         │      network-level route() can see the request.)
-        │   This applies to ALL task types (component, page, flow).
+        │
+        │   ├── component type → use worker.use() in .preview file to override handlers
+        │   └── page/flow type → modify the project's MSW handlers directly
+        │         (e.g., src/mocks/handlers.ts) or add conditional overrides
         │
         └── no MSW → use --mock-routes for page/flow types:
               --mock-routes visual-qa/mocks/<task>.json


### PR DESCRIPTION
## Summary
- PHASE 1 mock 전략을 MSW 존재 여부에 따라 분기하도록 변경
- MSW가 활성화된 환경에서 `--mock-routes`가 동작하지 않는 이유(Service Worker vs Network 레벨) 명시
- MSW 환경에서는 `worker.use()`를 사용하도록 안내

Closes #5

## Test plan
- [ ] SKILL.md PHASE 1 Step 2의 분기 트리가 MSW 여부로 먼저 나뉘는지 확인
- [ ] `--mock-routes` 미동작 경고가 포함되어 있는지 확인