### PR TITLE
SKILL.md: MSW 핸들러 URL 패턴 일치 가이드 추가

### DIFF
--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -131,6 +131,14 @@ Does the target make API calls?
               For component type, register mocks in .preview file.
 ```
 
+> **MSW handler URL matching:** When overriding handlers with `worker.use()`,
+> use the `*` glob prefix to match regardless of host:
+> ```ts
+> worker.use(http.get('*/your/endpoint', handler))
+> ```
+> This avoids mismatches between path-only (`/api/...`) and full-URL
+> (`http://localhost:3000/api/...`) registrations in existing handlers.
+
 > **localStorage-based stores:** Stores that read `localStorage` at module load
 > time will initialize **before** `onMount` or `addInitScript` can set values.
 > In the preview file, set store state directly via the store's API (e.g.,

--- a/skills/frontend-visual-tdd/scripts/capture.ts
+++ b/skills/frontend-visual-tdd/scripts/capture.ts
@@ -43,7 +43,6 @@ try {
   process.exit(1);
 }
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports -- dynamic guard
 const { chromium } = await import('playwright');
 
 // --- Types ---
@@ -126,7 +125,7 @@ try {
   if (mockRoutesPath) {
     const mockRoutes: MockRoute[] = JSON.parse(readFileSync(mockRoutesPath, 'utf-8'));
     for (const mock of mockRoutes) {
-      await page.route(mock.pattern, async (route: { abort: () => Promise<void>; fulfill: (opts: Record<string, unknown>) => Promise<void> }) => {
+      await page.route(mock.pattern, async (route) => {
         if (mock.abort) {
           await route.abort();
           return;


### PR DESCRIPTION
## Summary
- `worker.use()` 등록 시 `*` glob prefix로 호스트에 무관하게 매칭하는 패턴 안내 추가
- path-only vs full-URL 불일치 문제 해결 가이드

Closes #6

## Test plan
- [ ] SKILL.md Step 2 아래에 MSW URL 매칭 가이드가 포함되어 있는지 확인
- [ ] `*/your/endpoint` 패턴 예시가 올바른지 확인