### PR TITLE
SKILL.md: Store 초기화 순서와 localStorage mock 가이드 추가

### DIFF
--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -118,6 +118,12 @@ Does the target make API calls?
   └── no API calls → proceed without --mock-routes
 ```
 
+> **localStorage-based stores:** Stores that read `localStorage` at module load
+> time will initialize **before** `onMount` or `addInitScript` can set values.
+> In the preview file, set store state directly via the store's API (e.g.,
+> `store.set(...)`, `store.rehydrate()`) rather than writing to `localStorage`
+> after mount.
+
 **Step 3. Capture actual screenshot:**
 ```bash
 npx tsx .claude/skills/frontend-visual-tdd/scripts/capture.ts \


### PR DESCRIPTION
## Summary
- localStorage 기반 store의 초기화 순서(module load > onMount) 주의사항 추가
- preview에서 store API를 직접 호출하는 패턴 안내

Closes #7

## Test plan
- [ ] SKILL.md Step 2 아래에 localStorage store 가이드가 포함되어 있는지 확인