### PR TITLE
SKILL.md: Expected/Actual 이미지 스케일 불일치 방지 가이드 추가

### DIFF
--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -98,6 +98,13 @@ What kind of task is this?
 
 See `references/figma-mcp.md` for nodeId lookup and image extraction.
 
+> **Scale matching:** Expected and actual images must have the same pixel
+> dimensions. Use `--scale 1` in figma-export.ts (default) to match
+> Playwright's default deviceScaleFactor of 1. If you need 2x resolution,
+> set both: `figma-export.ts --scale 2` and `capture.ts --device-scale-factor 2`.
+> Mismatched scales cause inflated diff percentages (e.g., 76%) due to
+> resize artifacts and anti-aliasing.
+
 ---
 
 ### PHASE 1 — Confirm RED


### PR DESCRIPTION
## Summary
- PHASE 0에 expected/actual 이미지 스케일 일치 원칙 추가
- `figma-export.ts --scale`과 Playwright `deviceScaleFactor`를 맞춰야 함을 명시
- 불일치 시 발생하는 문제(76% diff 등) 경고

Closes #8

## Test plan
- [ ] SKILL.md PHASE 0 아래에 스케일 매칭 가이드가 포함되어 있는지 확인