### PR TITLE
SKILL.md: 전체 페이지 vs 콘텐츠 영역 비교 전략 가이드 추가

### DIFF
--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -104,12 +104,12 @@ See `references/figma-mcp.md` for nodeId lookup and image extraction.
 > available:
 > - **Content node exists in Figma** → export that node's nodeId directly,
 >   set capture.ts viewport to match its dimensions. No cropping needed.
-> - **Only full page frame available** → either include the layout in the
->   preview (mock auth store, add nav/sidebar), or raise the diff threshold
->   to account for layout differences.
+> - **Only full page frame available** → include the layout in the
+>   preview (mock auth store, add nav/sidebar) so the capture matches the
+>   Figma frame structurally.
 >
-> Avoid using `--selector` to crop content areas — element boundaries shift
-> with dynamic content, causing unreliable diffs.
+> Do not add a `--selector` cropping option — element boundaries shift
+> with dynamic content, making selector-based diffs unreliable.
 
 ---
 

--- a/skills/frontend-visual-tdd/SKILL.md
+++ b/skills/frontend-visual-tdd/SKILL.md
@@ -98,6 +98,19 @@ What kind of task is this?
 
 See `references/figma-mcp.md` for nodeId lookup and image extraction.
 
+> **Full page vs content area comparison:**
+> Figma expected images may include the full layout (nav, sidebar) while the
+> preview only renders the content area. Choose a strategy based on what's
+> available:
+> - **Content node exists in Figma** → export that node's nodeId directly,
+>   set capture.ts viewport to match its dimensions. No cropping needed.
+> - **Only full page frame available** → either include the layout in the
+>   preview (mock auth store, add nav/sidebar), or raise the diff threshold
+>   to account for layout differences.
+>
+> Avoid using `--selector` to crop content areas — element boundaries shift
+> with dynamic content, causing unreliable diffs.
+
 ---
 
 ### PHASE 1 — Confirm RED


### PR DESCRIPTION
## Summary
- PHASE 0에 Figma 노드 구조에 따른 비교 전략 선택 가이드 추가
- 콘텐츠 노드 직접 export vs 레이아웃 포함 렌더링 분기
- `--selector` 기반 크롭은 불안정하므로 지양 안내

Closes #9

## Test plan
- [ ] SKILL.md PHASE 0에 비교 전략 가이드가 포함되어 있는지 확인
- [ ] --selector 지양 안내가 명시되어 있는지 확인