### PR TITLE
refactor: SKILL.md superpowers 스타일 리팩터링

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,14 @@ npm run setup
 ### Two feedback loops
 
 ```
-PHASE 0  Gather Figma design + generate interaction spec (AI proposes, human confirms)
+PHASE 0  Gather Figma design + generate interaction spec
+  ↓ [user confirms spec]
 PHASE 1  Classify complexity (style-only / interactive / ambiguous)
+  ↓ [user confirms classification]
 PHASE 2  Interaction TDD — write Playwright tests → RED → implement → GREEN
+  ↓ [user confirms to proceed]
 PHASE 3  Visual verification — capture screenshot → compare with Figma → iterate
+  ↓ [user confirms visual match]
 PHASE 4  Save baseline + accumulate harness artifacts in project
 ```
 

--- a/skills/fe-harness/SKILL.md
+++ b/skills/fe-harness/SKILL.md
@@ -1,224 +1,142 @@
 ---
 name: fe-harness
 description: >
-  Use this skill when implementing any frontend UI work — building components,
-  implementing pages, changing styles, or creating interaction flows. Activate
-  when working from a Figma design or when the user asks to "implement this
-  design", "build this component", "match this mockup", or any frontend task
-  needing quality verification, even if they don't mention testing or QA.
-  Runs interaction TDD with Playwright, then visual verification against Figma.
-compatibility: Requires Node.js 18+, Playwright, Figma Personal Access Token (figd_*)
-allowed-tools: Bash(npx:*) Bash(npm:*) Read Write Edit Glob Grep
+  Use when implementing any frontend UI work — building components,
+  implementing pages, changing styles, or creating interaction flows.
+  Activate when working from a Figma design or when the user asks to
+  "implement this design", "build this component", "match this mockup",
+  or any frontend task needing quality verification.
 ---
 
 # Frontend Harness
 
-Two-loop feedback harness for frontend UI work:
-**Interaction TDD** (behavior) then **Visual Verification** (appearance).
+Two-loop feedback harness: **Interaction TDD** (behavior) then **Visual Verification** (appearance).
+
+Proceed through phases one at a time. At each phase boundary,
+**stop, show what you did, and ask the user before moving on.**
 
 ```
-PHASE 0: Context & Spec ─→ PHASE 1: Classify ─→ PHASE 2: Interaction TDD ─→ PHASE 3: Visual Verify ─→ PHASE 4: Complete
-                                    │                                              ▲
-                                    └── style-only ────────────────────────────────┘
+PHASE 0 → PHASE 1 → PHASE 2 → PHASE 3 → PHASE 4
+Context    Classify   TDD        Visual     Complete
+  ↓          ↓         ↓          ↓          ↓
+ [ask]     [ask]     [ask]      [ask]      [done]
 ```
 
-## Setup
-
-Run once after installing the skill:
+## Setup (once per project)
 
 ```bash
-cd skills/fe-harness/scripts
-npm run setup        # installs deps + downloads Chromium
+cd skills/fe-harness/scripts && npm run setup
 ```
-
----
 
 ## Gotchas
 
-- **Figma MCP screenshots ≠ files.** `get_design_context` returns an inline
-  image for conversation reference only — it cannot be saved to disk. Always
-  use `figma-export.ts` (REST API) for images that need to exist as files.
-- **No pixel-diff for Figma vs browser.** Font rendering and anti-aliasing
-  make pixel comparison unreliable across rendering engines. Use Claude visual
-  comparison for Figma-to-browser. `diff.ts` is for browser-to-browser
-  regression only.
-- **Figma nodeId format.** URL `node-id=123-456` → API `123:456` (dash → colon).
-- **Stall counter = 3.** If passing test count doesn't increase for 3
-  consecutive runs, stop and escalate to the human.
+- **Figma MCP screenshots cannot be saved to disk.** Use `figma-export.ts` for files.
+- **No pixel-diff for Figma vs browser.** Use Claude visual comparison. `diff.ts` is browser-to-browser only.
+- **Figma nodeId format.** URL `node-id=123-456` → API `123:456`.
+- **Stall counter = 3.** Stop and escalate after 3 consecutive non-improvements.
 
 ---
 
-## PHASE 0 — Context & Spec Generation
+## PHASE 0 — Context & Spec
 
-### Step 1. Gather Figma design
+1. **Figma design spec** — call `mcp__figma__get_design_context({ fileKey, nodeId })` to get tokens, spacing, structure, and frame dimensions.
 
-**1a. Design spec via Figma MCP:**
+2. **Figma expected image** — download via REST API:
+   ```bash
+   npx tsx skills/fe-harness/scripts/figma-export.ts \
+     --file-key <FILE_KEY> --node-ids <NODE_ID> \
+     --out visual-qa/expected --scale 1
+   ```
+   See [references/figma-reference.md](references/figma-reference.md) for nodeId and scale details.
 
-```
-mcp__figma__get_design_context({ fileKey, nodeId })
-→ design tokens, colors, spacing, component structure
-→ inline screenshot (conversation reference only — CANNOT be saved to disk)
-→ frame width × height (for viewport matching)
-```
+3. **Generate interaction spec** — synthesize Figma + task description into:
+   - Initial state (what user sees on load)
+   - Interactions (action → expected result)
+   - Edge cases (error, empty, loading)
+   - API calls (endpoint + mock response shape)
 
-**1b. Expected image via Figma REST API:**
+   See [references/spec-template.md](references/spec-template.md) for full template.
 
-> Use `figma-export.ts` for disk images — MCP screenshots are conversation-only (see Gotchas).
+4. **Clarify unknowns** — ask the user when: no state variants in Figma, unclear post-click behavior, unknown API handling, unclear conditional rendering.
 
-```bash
-export FIGMA_TOKEN=<TOKEN>   # or set in .env
-npx tsx skills/fe-harness/scripts/figma-export.ts \
-  --file-key <FILE_KEY> --node-ids <NODE_ID> \
-  --out visual-qa/expected --scale 1
-```
+### STOP — present spec and ask:
+> "Spec이 맞는지 확인해주세요. 수정할 부분이 있으면 알려주세요."
 
-See [references/figma-reference.md](references/figma-reference.md) for nodeId lookup
-and scale matching details.
-
-### Step 2. Generate interaction spec
-
-Synthesize Figma design + task description into a structured spec:
-
-```markdown
-## Interaction Spec
-
-### Component: <Name>
-
-**Initial state:**
-- [describe what user sees on load]
-
-**Interactions:**
-1. [action] → [expected result]
-2. [action] → [expected result]
-
-**Edge cases:**
-- [error state, empty state, loading state, etc.]
-
-**API calls:**
-- [endpoint] → [mock response shape]
-```
-
-See [references/spec-template.md](references/spec-template.md) for full template.
-
-### Step 3. Clarify unknowns
-
-Ask the human when:
-- Figma has no state variants (hover, loading, error) but they're expected
-- Buttons exist but post-click behavior is unclear
-- API calls are expected but success/failure handling isn't in the design
-- Conditional rendering exists but conditions are unclear
-
-### Step 4. Human confirms spec
-
-Present the generated spec. Human confirms or modifies. Spec is finalized.
+**Do NOT proceed until the user confirms.**
 
 ---
 
-## PHASE 1 — Complexity Classification
+## PHASE 1 — Classify
 
-Classify **before** any implementation.
+Classify the task:
 
-| Complexity | Criteria | Path |
-|------------|----------|------|
-| **style-only** | Color, spacing, font, layout changes. No new interactions. | Skip PHASE 2 → PHASE 3 |
-| **interactive** | New component, form, modal, navigation, state changes. | PHASE 2 → PHASE 3 |
-| **ambiguous** | Unclear whether interactions change. | Ask human (see below) |
+| Type | Criteria | Path |
+|------|----------|------|
+| **style-only** | Color, spacing, font, layout. No new interactions. | Skip PHASE 2 → PHASE 3 |
+| **interactive** | New component, form, modal, navigation, state. | PHASE 2 → PHASE 3 |
+| **ambiguous** | Unclear. | Ask the user. |
 
-**When ambiguous, ask:**
-- "This task changes styles only, or are there interaction changes too?"
-- "Do we need interaction specs for this?"
-- "Does existing behavior stay the same?"
+### STOP — present classification and ask:
+> "이 작업은 [type]으로 분류했습니다. [이유]. 맞을까요?"
+
+**Do NOT proceed until the user confirms.**
 
 ---
 
-## PHASE 2 — Interaction TDD Loop
+## PHASE 2 — Interaction TDD
 
 > Skipped for style-only tasks.
 
-### Prerequisites
+### 2-1. Setup prerequisites
 
-**Playwright Test setup** — if the project doesn't have it, set it up:
-- `playwright.config.ts` at project root
-- `e2e/` directory for test files
-- This setup is **permanent** — it stays in the project as harness infrastructure.
+- **Playwright** — if not present, create `playwright.config.ts` + `e2e/` directory.
+- **Preview route** — for component tasks: `/dev/preview?component=<Name>`, outside auth, dev-only guard.
 
-**`/dev/preview` route** — for component-type tasks:
-- URL pattern: `/dev/preview?component=<ComponentName>`
-- Place outside auth layout groups (no login required)
-- Add dev-only guard (`import.meta.env.DEV` or equivalent)
-- Separate preview wrapper per component (e.g., `<Name>.preview.tsx`)
-- For components with API calls: register MSW handlers or use `page.route()`
-  in the preview file
+### 2-2. Write Playwright tests FIRST (RED)
 
-### Step 1. Write all Playwright tests (before implementation)
-
-Write tests for **all** spec items at once in `e2e/<task>.spec.ts`. Tests MUST fail (RED).
-
-- Base URL for component tasks: `/dev/preview?component=<Name>`
+Write ALL tests for spec items in `e2e/<task>.spec.ts` **before** any implementation.
 - One `test()` per interaction spec item
-- Prefer role-based selectors (`getByRole`, `getByLabel`)
+- Prefer `getByRole`, `getByLabel` selectors
+- Component base URL: `/dev/preview?component=<Name>`
 
-### Step 2. Handle API mocking
+### 2-3. Handle API mocking
 
-```
-Does the component make API calls?
-  │
-  ├── No → proceed without mocking
-  │
-  └── Yes → detect project mocking infrastructure:
-        │
-        ├── MSW present (msw in package.json)
-        │   → Use existing handlers or add new ones
-        │   → In preview files: worker.use(http.get('*/endpoint', handler))
-        │
-        └── No MSW
-            → Use page.route() inline in test files:
-              await page.route('**/api/login', route =>
-                route.fulfill({ status: 200, body: JSON.stringify({ token: '...' }) })
-              );
+- MSW present → use existing handlers or add new ones
+- No MSW → use `page.route()` inline in tests
+- Mock data in `e2e/mocks/`. See [references/mock-routes-example.json](references/mock-routes-example.json).
+- Unknown endpoints → ask the user.
 
-If API endpoints or response shapes are unknown → ask human.
-```
-
-Mock data is stored in `e2e/mocks/` for reuse across tests.
-
-### Step 3. Confirm RED
+### 2-4. Confirm RED
 
 ```bash
 npx playwright test e2e/<task>.spec.ts
 ```
-
 All tests must fail. If any pass unexpectedly, investigate.
 
-### Step 4. Implement → GREEN
+### 2-5. Implement → GREEN
 
 Implement the component/page. Run tests after each significant change.
 
-**Exit condition — stall counter:**
-```
-After each test run:
-  Did the number of passing tests increase?
-    ├── Yes → continue (progress)
-    └── No  → stall counter +1
+**Stall counter:** if passing test count doesn't increase for 3 consecutive runs → stop and escalate:
+> "N/M tests passing. Stuck on: [failing test names]. Need guidance."
 
-Stall counter reaches 3 → stop and escalate to human:
-  "N/M tests passing. Stuck on: [failing test names]. Need guidance."
-```
+### STOP — show test results and ask:
+> "모든 인터랙션 테스트가 통과했습니다. (N/N) Visual verification으로 넘어갈까요?"
+
+**Do NOT proceed until the user confirms.**
 
 ---
 
-## PHASE 3 — Visual Verification Loop
+## PHASE 3 — Visual Verification
 
-Entered after PHASE 2 GREEN (or directly for style-only tasks).
-
-### Step 1. Start dev server if not running
+### 3-1. Start dev server if not running
 
 ```bash
 npm run dev &
 npx wait-on http://localhost:<PORT>
 ```
 
-### Step 2. Capture screenshot
+### 3-2. Capture screenshot
 
 ```bash
 npx tsx skills/fe-harness/scripts/capture.ts \
@@ -227,89 +145,46 @@ npx tsx skills/fe-harness/scripts/capture.ts \
   --type <component|page|flow> \
   --width <W> --height <H>
 ```
+Width/height must match Figma frame dimensions from PHASE 0.
 
-Width/height must match the Figma frame dimensions from PHASE 0.
+### 3-3. Compare with Figma (Claude visual comparison)
 
-### Step 3. Compare with Figma (Claude visual comparison)
+Present both images side by side:
+1. Figma expected: `visual-qa/expected/<task>.png`
+2. Browser actual: `visual-qa/actual/<task>.png`
 
-> Figma vs browser → use Claude visual comparison, not diff.ts (see Gotchas).
+Judge: layout, spacing, colors, typography, overall fidelity.
 
-Present both images to Claude for comparison:
-1. The Figma expected image (`visual-qa/expected/<task>.png`)
-2. The captured screenshot (`visual-qa/actual/<task>.png`)
+### 3-4. Iterate
 
-Claude judges: layout, spacing, colors, typography, overall fidelity.
+If differences found: fix CSS → wait for hot reload → re-capture → re-compare.
 
-### Step 4. Iterate
+**Stall counter:** same as PHASE 2 (3 stalls → escalate to user).
 
-If Claude identifies differences:
-- Fix CSS/styles
-- Wait for hot reload
-- Re-run capture.ts (Step 2)
-- Re-compare (Step 3)
+### 3-5. Save baseline
 
-**Exit condition:** same stall counter as PHASE 2 (3 stalls → escalate).
+Copy final screenshot to `visual-qa/expected/<task>-baseline.png`.
 
-### Step 5. Save baseline
+### STOP — show comparison and ask:
+> "Figma 디자인과 비교 결과 시각적으로 일치합니다. 완료 처리할까요?"
 
-When visual verification passes:
-- The final actual screenshot becomes the **regression baseline**
-- Copy to `visual-qa/expected/<task>-baseline.png`
-- Future changes use `diff.ts` (pixelmatch) against this baseline
-  (browser vs browser comparison IS reliable)
+**Do NOT proceed until the user confirms.**
 
 ---
 
-## PHASE 4 — Completion & Harness Accumulation
+## PHASE 4 — Completion
 
-### Artifacts that stay in the project
+Ensure `.gitignore` includes `visual-qa/actual/` and `visual-qa/diff/`.
 
+Present the artifacts created:
 ```
-e2e/<task>.spec.ts              ← interaction tests (cumulative)
-e2e/mocks/                      ← API mock data (reusable)
-dev/preview/<Component>.tsx     ← preview routes (cumulative)
-visual-qa/expected/             ← baseline screenshots (commit)
-visual-qa/config.json           ← per-task thresholds (commit)
-playwright.config.ts            ← created once, permanent
-```
-
-### .gitignore additions
-
-```
-visual-qa/actual/
-visual-qa/diff/
+e2e/<task>.spec.ts              ← interaction tests
+e2e/mocks/                      ← API mock data
+dev/preview/<Component>.tsx     ← preview route
+visual-qa/expected/             ← baseline screenshots
+playwright.config.ts            ← project config
 ```
 
-### Regression: diff.ts for future changes
+See [references/ci-guide.md](references/ci-guide.md) for CI integration.
 
-After baseline is established, future tasks can run:
-
-```bash
-npx tsx skills/fe-harness/scripts/diff.ts \
-  --expected visual-qa/expected/<task>-baseline.png \
-  --actual   visual-qa/actual/<task>.png \
-  --diff     visual-qa/diff/<task>.png \
-  --threshold 0.5
-```
-
-This catches unintended visual regressions (browser vs browser = reliable).
-
----
-
-## Checklist
-
-- [ ] Figma design gathered (MCP for spec, REST API for expected image)
-- [ ] Interaction spec generated and confirmed by human
-- [ ] Complexity classified (style-only / interactive / ambiguous → asked)
-- [ ] `/dev/preview` route exists (component tasks)
-- [ ] API mocking strategy determined (MSW / page.route / none)
-- [ ] PHASE 2: All interaction tests written → RED confirmed → GREEN achieved
-- [ ] PHASE 3: capture.ts screenshot → Claude comparison → visual GREEN
-- [ ] PHASE 4: Baseline saved, artifacts committed
-
----
-
-## CI Integration
-
-See [references/ci-guide.md](references/ci-guide.md) for guidance on running
-interaction tests and visual regression in CI pipelines.
+Announce completion.


### PR DESCRIPTION
## Summary
- SKILL.md를 316줄 → 190줄로 경량화 (비표준 frontmatter 제거, 중복 설명 축약)
- 매 Phase 완료 후 `### STOP` 승인 게이트 추가 — 사용자 확인 없이 다음 Phase로 넘어가지 않음
- description에서 워크플로우 요약 제거, 트리거 조건만 기술
- 핵심 워크플로우 단계는 SKILL.md에 인라인 유지 (reference 파일 위임 X)

## Test plan
- [ ] fe-harness 스킬 트리거 후 Phase 0에서 spec 제시 → 사용자 승인 대기 확인
- [ ] Phase 1 분류 후 사용자에게 확인 요청하는지 검증
- [ ] Phase 2에서 Playwright 테스트를 먼저 작성하고 RED 확인하는지 검증
- [ ] Phase 3 visual verification 수행 확인
- [ ] 각 Phase 사이에서 자동으로 넘어가지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)