### PR TITLE
fix: preview가 실제 컴포넌트를 import하도록 강제

### DIFF
--- a/skills/fe-harness/SKILL.md
+++ b/skills/fe-harness/SKILL.md
@@ -93,6 +93,7 @@ npx playwright install chromium --with-deps
   consecutive runs, stop and escalate to the human.
 - **Workflow B does NOT use Figma MCP.** Image download uses REST API only
   (`figma-export.ts`). Visual comparison uses Claude vision on local files only.
+- **Preview ≠ Production.** Duplicating markup means visual TDD verifies the copy, not the real page. See [references/preview-guide.md](references/preview-guide.md).
 
 ---
 
@@ -192,6 +193,10 @@ Tell the user:
 Set up if not present: `playwright.config.ts` at root, `e2e/` directory.
 For component tasks, create a `/dev/preview?component=<Name>` route (dev-only guard, outside auth layout).
 See [references/test-setup-guide.md](references/test-setup-guide.md) for full setup details.
+
+**CRITICAL:** Preview must import real production components — never copy-paste markup.
+See [references/preview-guide.md](references/preview-guide.md) for construction rules,
+file-based router handling, and monorepo setup.
 
 ### Test base URL by task type
 
@@ -312,36 +317,9 @@ Tell the user:
 
 ### Step 1. Enumerate capture targets — Visual Test List
 
-Before downloading, build a **Visual Test List** from Phase 0's Figma nodes.
-Every nodeId from Phase 0 MUST appear as at least one test item. Do NOT make
-additional Figma MCP calls — use the data already gathered.
-
-**Rule: nodeId count = minimum test count.** If Phase 0 saved 3 nodeIds, the
-Visual Test List must have at least 3 items (one per nodeId). Additional items
-(interactive states, data variants) may be added on top.
-
-```
-Build Visual Test List:
-  1. For EACH nodeId from Phase 0, create one test entry:
-     VT-1: <nodeId label> (nodeId: <X:Y>) → <figma-export filename>.png
-     VT-2: <nodeId label> (nodeId: <X:Y>) → <figma-export filename>.png
-     ...
-  2. For nodes with interactive states (hover, open, expanded, etc.),
-     add additional test entries with the SAME nodeId but different
-     capture conditions:
-     VT-N: <label> — <state> (nodeId: <X:Y>) → <filename>.png
-  3. Verify: every nodeId from Phase 0 has at least one VT entry.
-     If any nodeId is missing, add it before presenting.
-```
-
-**Visual Test List output format (present this exactly):**
-
-```
-Visual Test List (N items from M Figma nodes):
-  VT-1: [label] (nodeId: [X:Y], viewport: [WxH]) → expected/[name].png
-  VT-2: [label] (nodeId: [X:Y], viewport: [WxH]) → expected/[name].png
-  ...
-```
+Build a **Visual Test List** from Phase 0's Figma nodes (≥ 1 VT item per nodeId).
+See [references/figma-reference.md](references/figma-reference.md) §Visual Test List
+for the build procedure and output format.
 
 ### >>> STOP — Present Visual Test List to user and wait <<<
 
@@ -369,21 +347,9 @@ and scale matching details.
 
 ### Step 3. Verify download — ALL items
 
-Confirm expected images exist for EVERY Visual Test item:
-```bash
-ls -la visual-qa/expected/
-```
-
-Cross-check against the Visual Test List:
-```
-  VT-1: expected/[name].png — ✅ exists / ❌ missing
-  VT-2: expected/[name].png — ✅ exists / ❌ missing
-  ...
-```
-
-> **Do NOT proceed to Phase 6 until ALL expected image files exist.**
-> If any download fails, check FIGMA_TOKEN and nodeId format (must use colon: `123:456`).
-> Re-download missing items before continuing.
+Confirm expected images exist for EVERY Visual Test item (`ls -la visual-qa/expected/`).
+Cross-check each VT item: ✅ exists / ❌ missing. Do NOT proceed to Phase 6 until ALL exist.
+If any download fails, check FIGMA_TOKEN and nodeId format (colon: `123:456`).
 
 ---
 
@@ -456,7 +422,13 @@ If Claude identifies differences:
 When this target passes, mark it done and move to the **next target**.
 
 **IMPORTANT: Do NOT skip remaining targets. ALL targets must reach visual GREEN
-before proceeding to Step 5.**
+before proceeding to Step 4-b.**
+
+#### Step 4-b. Verify actual route (when accessible)
+
+After ALL preview targets pass, capture the actual production route and compare
+it against the preview screenshot to detect drift.
+See [references/route-verification.md](references/route-verification.md) for details.
 
 ### Step 5. Save baselines
 
@@ -509,7 +481,8 @@ See [references/completion-guide.md](references/completion-guide.md) for artifac
 - [ ] **5-3.** Download verified — ALL VT items have expected images on disk
 - [ ] **6-1.** capture.ts screenshot taken for EACH VT item (one per state/variant)
 - [ ] **6-2.** Claude visual comparison for EACH VT item (local files only, no MCP)
-- [ ] **6-3.** ALL VT items marked ✅ PASS — no item skipped — **STOP, wait for user**
+- [ ] **6-3.** ALL VT items marked ✅ PASS — no item skipped
+- [ ] **6-4.** Actual route vs preview comparison (Step 4-b) — drift check passed — **STOP, wait for user**
 - [ ] **7-1.** Baseline saved, artifacts committed
 
 ---

--- a/skills/fe-harness/references/figma-reference.md
+++ b/skills/fe-harness/references/figma-reference.md
@@ -72,3 +72,37 @@ npx tsx skills/fe-harness/scripts/figma-export.ts \
 Expected and actual images must have the same pixel dimensions:
 - `--scale 1` (default) matches Playwright's default `deviceScaleFactor: 1`
 - For 2x: use both `figma-export.ts --scale 2` and `capture.ts --device-scale-factor 2`
+
+---
+
+## Visual Test List — Build Procedure
+
+Before downloading expected images, build a Visual Test List from Phase 0's
+Figma nodes. Every nodeId from Phase 0 MUST appear as at least one test item.
+Do NOT make additional Figma MCP calls — use the data already gathered.
+
+**Rule: nodeId count = minimum test count.** If Phase 0 saved 3 nodeIds, the
+Visual Test List must have at least 3 items (one per nodeId).
+
+### Steps
+
+1. For EACH nodeId from Phase 0, create one test entry:
+   ```
+   VT-1: <nodeId label> (nodeId: <X:Y>) → <figma-export filename>.png
+   VT-2: <nodeId label> (nodeId: <X:Y>) → <figma-export filename>.png
+   ```
+2. For nodes with interactive states (hover, open, expanded, etc.),
+   add additional entries with the SAME nodeId but different capture conditions:
+   ```
+   VT-N: <label> — <state> (nodeId: <X:Y>) → <filename>.png
+   ```
+3. Verify: every nodeId from Phase 0 has at least one VT entry.
+
+### Output format (present this exactly)
+
+```
+Visual Test List (N items from M Figma nodes):
+  VT-1: [label] (nodeId: [X:Y], viewport: [WxH]) → expected/[name].png
+  VT-2: [label] (nodeId: [X:Y], viewport: [WxH]) → expected/[name].png
+  ...
+```

--- a/skills/fe-harness/references/preview-guide.md
+++ b/skills/fe-harness/references/preview-guide.md
@@ -1,0 +1,33 @@
+# Preview Construction Guide
+
+## Construction rules (CRITICAL)
+
+- Preview MUST import and render actual production components.
+  Duplicating markup makes visual verification meaningless —
+  it verifies the copy, not the real code.
+- Import sub-components that accept props, pass mock data as props.
+- If a page component calls API hooks internally, import its
+  presentational sub-components instead. If none exist, extract
+  the UI into a presentational component first, then use that
+  in both the page and the preview.
+- NEVER copy-paste JSX from the target component into the preview.
+
+## File-based router
+
+If the project uses a file-based router (TanStack Router, Next.js, etc.),
+preview files placed under route directories (e.g., `dev/preview/<Component>.tsx`)
+may be interpreted as actual routes. Follow the project's routing conventions for
+preview file placement — e.g., use a `_dev` prefix, a non-route directory, or
+the router's file-exclusion pattern.
+
+## Monorepo
+
+In monorepo setups where e2e tests live in a separate package
+(e.g., `apps/my-app-e2e/`):
+
+- Preview files must be placed inside the **main app** package
+  (where the dev server runs), not in the e2e package.
+- `playwright.config.ts` lives in the e2e package, not project root.
+- The e2e package cannot directly import main app components —
+  tests interact only via browser URLs.
+- Adjust file paths in this guide to match your monorepo structure.

--- a/skills/fe-harness/references/route-verification.md
+++ b/skills/fe-harness/references/route-verification.md
@@ -1,0 +1,29 @@
+# Actual Route Verification (Step 4-b)
+
+After ALL preview-based visual tests pass, also capture the **actual
+production route** if it can be accessed (e.g., via MSW mock mode or
+seeded auth). Compare the actual route screenshot against the preview
+screenshot to detect drift. If they differ significantly, the preview
+was not constructed correctly — it likely duplicates markup instead of
+importing real components. Fix the preview before proceeding.
+
+## Capture
+
+```bash
+npx tsx scripts/capture.ts \
+  --url  http://localhost:<PORT>/<actual-route> \
+  --out  visual-qa/actual/<target-name>-route.png \
+  --type page \
+  --width <W> --height <H>
+```
+
+## Compare
+
+Compare `visual-qa/actual/<target-name>.png` (preview) against
+`visual-qa/actual/<target-name>-route.png` (actual route) using Claude
+visual comparison. If the two diverge, the preview is not representative.
+
+## When to skip
+
+Skip this step only if the actual route is inaccessible (e.g.,
+requires real auth, external services, or data that cannot be mocked).


### PR DESCRIPTION
## Summary
- Preview가 마크업을 복사하지 않고 실제 프로덕션 컴포넌트를 import하도록 강제하는 규칙 추가
- Phase 6에 실제 라우트 이중 검증(Step 4-b) 추가로 preview와 실제 페이지 간 drift 감지
- 파일 기반 라우터, 모노레포 환경 가이드를 reference로 분리하여 SKILL.md 493줄 유지

## Changes
- `SKILL.md`: Gotchas 경고, Phase 2 preview 규칙 참조, Phase 6 Step 4-b, 체크리스트 6-4 추가
- `references/preview-guide.md` (신규): 구성 규칙, 파일 기반 라우터, 모노레포 안내
- `references/route-verification.md` (신규): 실제 라우트 drift 감지 절차
- `references/figma-reference.md`: VT List 빌드 절차 병합

## Test plan
- [ ] SKILL.md가 500줄 이하인지 확인 (현재 493줄)
- [ ] reference 파일 링크가 정상 작동하는지 확인
- [ ] style-only 작업에서 Workflow B 진행 시 preview 규칙이 적용되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)