### PR TITLE
feat: Phase 7 완료 시 구조화된 결과 리포트 출력 강제

### DIFF
--- a/skills/fe-harness/SKILL.md
+++ b/skills/fe-harness/SKILL.md
@@ -456,9 +456,19 @@ If any VT items remain ⬜ or ❌, you are NOT done. Continue processing.
 
 ---
 
-## PHASE 7 — Completion & Harness Accumulation
+## PHASE 7 — Completion & Report
 
-See [references/completion-guide.md](references/completion-guide.md) for artifact list, .gitignore additions, and regression testing setup.
+### Completion Report (MANDATORY)
+
+**You MUST output a structured completion report to the user.** Never end with just "완료" or a generic message. Follow the report template in [references/completion-guide.md](references/completion-guide.md).
+
+The report must include:
+1. Workflow A results (classification, test counts, TDD cycle details, stall info)
+2. Workflow B results (Visual Test List outcomes per VT item, iteration counts)
+3. All created/modified files with descriptions
+4. Issues or notes
+
+See [references/completion-guide.md](references/completion-guide.md) for the full template, artifact list, .gitignore additions, and regression testing setup.
 
 ---
 

--- a/skills/fe-harness/references/completion-guide.md
+++ b/skills/fe-harness/references/completion-guide.md
@@ -1,5 +1,44 @@
 # Phase 7 — Completion Guide
 
+## Completion Report (MUST output to user)
+
+When all workflows finish, output a structured summary. This is **mandatory** — never end with just "완료" or similar without this report.
+
+```markdown
+## Fe-Harness 완료 리포트
+
+### Workflow A — Interaction TDD
+- **분류**: <style-only | interactive> (style-only이면 "스킵됨" 표시)
+- **테스트 파일**: `e2e/<task>.spec.ts`
+- **결과**: <N>/<Total> 테스트 통과
+- **TDD 사이클**: RED(<N>개 실패) → GREEN(<N>회 반복 후 전체 통과)
+- **stall 발생**: <없음 | N회 — 원인: ...>
+
+### Workflow B — Visual TDD
+- **Visual Test List**: N개 항목
+- **Figma 이미지**: `visual-qa/expected/` — N개 다운로드 완료
+- **시각 비교 결과**:
+  - VT-1: [label] — PASS (N회 반복)
+  - VT-2: [label] — PASS
+  - ...
+- **베이스라인 저장**: `visual-qa/expected/<task>-baseline.png`
+
+### 생성/수정된 파일
+- `<file1>` — <설명>
+- `<file2>` — <설명>
+- ...
+
+### 이슈 및 참고사항
+- <특이사항, 스킵한 항목, 수동 확인 필요 사항 등. 없으면 "없음">
+```
+
+**Rules:**
+- If a workflow was skipped (e.g., style-only skips Workflow A), still include it with "스킵됨" and the reason.
+- If escalation happened (stall counter hit 3), include the failing test names and what was tried.
+- Always list ALL created/modified files with brief descriptions.
+
+---
+
 ## Artifacts that stay in the project
 
 ```


### PR DESCRIPTION
## Summary
- 스킬 완료 후 "완료 상태입니다"만 출력하고 TDD 결과를 보여주지 않는 문제 해결
- `SKILL.md` Phase 7에 mandatory completion report 지시 추가
- `completion-guide.md`에 Workflow A/B 결과, 파일 목록, 이슈를 포함하는 리포트 템플릿 추가

## Test plan
- [ ] fe-harness 스킬로 UI 작업 수행 후 Phase 7에서 구조화된 리포트가 출력되는지 확인
- [ ] style-only 태스크에서 Workflow A가 "스킵됨"으로 표시되는지 확인
- [ ] stall 발생 시 리포트에 실패한 테스트명과 시도 내용이 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)