### PR TITLE
chore: add Claude Code plugin manifest

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "fe-harness",
+  "description": "Frontend development skill suite with two feedback loops — Playwright-based Interaction TDD and Figma-based Visual Verification. Bundles fe-spec, fe-interaction-tdd, fe-visual-tdd, and the orchestrating fe-harness skills.",
+  "version": "0.1.0",
+  "author": {
+    "name": "ludacirs",
+    "url": "https://github.com/ludacirs"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `.claude-plugin/plugin.json` so this repo can be registered as an **External** plugin in Claude Code plugin marketplaces (e.g. [TeamPIA/pia-agent-tools](https://github.com/TeamPIA/pia-agent-tools)) and installed via `/plugin install fe-harness@…`.
- The existing `skills/` layout (`fe-harness`, `fe-interaction-tdd`, `fe-spec`, `fe-visual-tdd`) is already compatible with Claude Code's auto-discovery — this only adds the wrapper manifest.

## Manifest
\`\`\`json
{
  "name": "fe-harness",
  "description": "Frontend development skill suite with two feedback loops — Playwright-based Interaction TDD and Figma-based Visual Verification. Bundles fe-spec, fe-interaction-tdd, fe-visual-tdd, and the orchestrating fe-harness skills.",
  "version": "0.1.0",
  "author": { "name": "ludacirs", "url": "https://github.com/ludacirs" }
}
\`\`\`

## Test plan
- [ ] \`/plugin marketplace add TeamPIA/pia-agent-tools\` followed by \`/plugin install fe-harness@pia-agent-tools\` succeeds once the hub entry lands
- [ ] Existing \`npx skills add ludacirs/fe-harness-skill\` flow is unaffected (manifest is additive)